### PR TITLE
Bump CouchDB to 3.5.1 and MongoDB to 7.0.28 in Dockerfiles, tests, an…

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -27,7 +27,7 @@ Key characteristics:
 ## Prerequisites
 - Node.js: 22.x (as enforced by package.json engines)
 - npm: 10+
-- One database backend available locally (CouchDB ≥3.4.3 or MongoDB ≥7.0), or use Docker Compose
+- One database backend available locally (CouchDB ≥3.5.1 or MongoDB ≥7.0.28), or use Docker Compose
 
 ## Local Development
 1) Clone and install

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ These are the versions this sample app is coming with:
 - Node.js (v22 or higher)
 - npm or pnpm
 - One of the following databases:
-  - CouchDB (v3.4.3 or higher)
-  - MongoDB (v7.0 or higher)
+  - CouchDB (v3.5.1 or higher)
+  - MongoDB (v7.0.28 or higher)
 
 Stable work on lower versions is not guaranteed.
 

--- a/__tests__/db/couchdb-note-repository.integration.test.js
+++ b/__tests__/db/couchdb-note-repository.integration.test.js
@@ -10,7 +10,7 @@ describe('CouchDbNoteRepository Integration Tests', () => {
     beforeAll(async () => {
         console.log('Starting CouchDB container...');
         // Start CouchDB container
-        container = await new GenericContainer('couchdb:3.4.3')
+        container = await new GenericContainer('couchdb:3.5.1')
             .withExposedPorts(5984)
             .withEnvironment({
                 COUCHDB_USER: 'admin',

--- a/__tests__/db/mongodb-note-repository.integration.test.js
+++ b/__tests__/db/mongodb-note-repository.integration.test.js
@@ -11,7 +11,7 @@ describe('MongoDbNoteRepository Integration Tests', () => {
     beforeAll(async () => {
         console.log('Starting MongoDB container...');
         // Start MongoDB container
-        container = await new GenericContainer('mongo:7.0.25-jammy')
+        container = await new GenericContainer('mongo:7.0.28-jammy')
             .withExposedPorts(27017)
             .withEnvironment({
                 MONGO_INITDB_ROOT_USERNAME: 'admin',

--- a/couchdb.Dockerfile
+++ b/couchdb.Dockerfile
@@ -1,14 +1,14 @@
 # Build stage for applying security updates
-FROM couchdb:3.4.3 AS build
+FROM couchdb:3.5.1 AS build
 
 # Update and install security patches
-# Use apt-get instead of apt for better script compatibility
 # Clean up apt cache to reduce image size
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get dist-upgrade -y && \
-    apt-get autoremove -y && \
-    apt-get clean && \
+RUN apt update && \
+    apt-mark hold couchdb && \
+    DEBIAN_FRONTEND=noninteractive apt upgrade -y -o Dpkg::Options::="--force-confold" && \
+    DEBIAN_FRONTEND=noninteractive apt full-upgrade -y -o Dpkg::Options::="--force-confold" && \
+    apt autoremove -y && \
+    apt clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Production stage
@@ -16,8 +16,8 @@ FROM build AS production
 
 # Add Dockerfile Labels
 LABEL title="CouchDB with Security Updates"
-LABEL description="CouchDB based on official couchdb:3.4.3 image with all security patches applied"
-LABEL version="3.4.3"
+LABEL description="CouchDB based on official couchdb:3.5.1 image with all security patches applied"
+LABEL version="3.5.1"
 LABEL maintainer="Vadim Starichkov <starichkovva@gmail.com>"
 LABEL license="MIT"
 LABEL source="https://github.com/starichkov/nodejs-simple-notes-app.git"

--- a/mongodb.Dockerfile
+++ b/mongodb.Dockerfile
@@ -1,14 +1,14 @@
 # Build stage for applying security updates
-FROM mongo:7.0.25-jammy AS build
+FROM mongo:7.0.28-jammy AS build
 
 # Update and install security patches
-# Use apt-get instead of apt for better script compatibility
 # Clean up apt cache to reduce image size
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get dist-upgrade -y && \
-    apt-get autoremove -y && \
-    apt-get clean && \
+RUN apt update && \
+    apt-mark hold mongodb-org* && \
+    DEBIAN_FRONTEND=noninteractive apt upgrade -y -o Dpkg::Options::="--force-confold" && \
+    DEBIAN_FRONTEND=noninteractive apt full-upgrade -y -o Dpkg::Options::="--force-confold" && \
+    apt autoremove -y && \
+    apt clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Production stage
@@ -16,8 +16,8 @@ FROM build AS production
 
 # Add Dockerfile Labels
 LABEL title="MongoDB with Security Updates"
-LABEL description="MongoDB based on official mongo:7.0.25-jammy image with all security patches applied"
-LABEL version="7.0.25"
+LABEL description="MongoDB based on official mongo:7.0.28-jammy image with all security patches applied"
+LABEL version="7.0.28"
 LABEL maintainer="Vadim Starichkov <starichkovva@gmail.com>"
 LABEL license="MIT"
 LABEL source="https://github.com/starichkov/nodejs-simple-notes-app.git"


### PR DESCRIPTION
…d documentation for enhanced compatibility and security.