### PR TITLE
Expand Node.js support to include version 24.x

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -36,11 +36,11 @@ jobs:
       run: npm run build --if-present
 
     - name: Run unit tests with coverage
-      if: matrix.node-version == '22.x'
+      if: matrix.node-version == '24.x'
       run: npm run test:coverage
 
     - name: Upload coverage to Codecov
-      if: matrix.node-version == '22.x'
+      if: matrix.node-version == '24.x'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -3,7 +3,7 @@
 These guidelines help Junie make minimal, correct changes to this repository and understand how to validate them.
 
 ## Project Overview
-A RESTful Notes API built with Node.js (ES Modules) and Express, featuring a database‑agnostic architecture with interchangeable NoSQL backends. The app currently supports CouchDB and MongoDB via repository implementations, includes a lightweight web UI, and provides JSDoc-based documentation and Jest tests. Target runtime is Node.js 22.
+A RESTful Notes API built with Node.js (ES Modules) and Express, featuring a database‑agnostic architecture with interchangeable NoSQL backends. The app currently supports CouchDB and MongoDB via repository implementations, includes a lightweight web UI, and provides JSDoc-based documentation and Jest tests. Target runtime includes Node.js 20, 22, and 24 (LTS versions).
 
 Key characteristics:
 - Layered design: Model → Repository (vendor-specific) → API (Express routes)
@@ -25,7 +25,7 @@ Key characteristics:
 - DOCUMENTATION.md — documentation workflow and tips
 
 ## Prerequisites
-- Node.js: 22.x (as enforced by package.json engines)
+- Node.js: 20.x, 22.x, or 24.x (as enforced by package.json engines)
 - npm: 10+
 - One database backend available locally (CouchDB ≥3.5.1 or MongoDB ≥7.0.28), or use Docker Compose
 
@@ -54,7 +54,7 @@ Ensure .env contains the required credentials before starting.
 - Run with coverage: npm run test:coverage
 - Open coverage report: npm run test:coverage:open (Linux requires xdg-open)
 Notes:
-- Jest runs under Node 22 with experimental VM modules flag set by the script
+- Jest runs under Node 24 with experimental VM modules flag set by the script
 
 ## Documentation
 - Generate docs: npm run docs
@@ -64,7 +64,7 @@ Notes:
 See DOCUMENTATION.md for details.
 
 ## Code Style and Conventions
-- ESM only ("type": "module"); prefer async/await and modern Node 22 APIs
+- ESM only ("type": "module"); prefer async/await and modern Node 24 APIs
 - Keep repository interface boundaries clean when touching data access code
 - Add or update Jest tests when changing behavior
 - JSDoc for public methods and API routes is encouraged
@@ -78,7 +78,7 @@ See DOCUMENTATION.md for details.
 - Make the minimal change required to satisfy the issue
 - When renaming code entities, use the dedicated rename tool so all references update safely
 - Prefer adding tests or adjusting existing ones to validate new behavior when applicable
-- Respect Node 22 engine; avoid adding dependencies unnecessarily
+- Respect the supported Node.js versions (20, 22, 24); avoid adding dependencies unnecessarily
 - If environment-sensitive features are involved, document .env expectations succinctly
 
 ## Helpful References

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -278,21 +278,21 @@ The JSDoc configuration is in `jsdoc.config.json`:
 ```
 
 ### Node.js Version Requirements
-The documentation system is optimized for **Node.js 22 LTS**:
+The documentation system supports **Node.js 20, 22, and 24 LTS**:
 
 ```json
-// package.json
-"engines": {
-  "node": ">=22.0.0 <23.0.0",  // LTS 22.x only
-  "npm": ">=10.0.0"
+{
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  }
 }
 ```
 
-**Why LTS 22.x?**
-- ✅ **Stability**: Long-term support with 30+ months lifecycle
-- ✅ **Performance**: Latest optimizations and ES module support
-- ✅ **Compatibility**: All JSDoc and tooling dependencies supported
-- ✅ **CI/CD**: Consistent environment across local and GitHub Actions
+**Supported LTS Versions:**
+- ✅ **Node.js 24**: Primary development and CI version
+- ✅ **Node.js 22**: Supported LTS
+- ✅ **Node.js 20**: Supported LTS
 
 ## Integration with Development Workflow
 
@@ -316,7 +316,7 @@ jobs:
     steps:
       # 1. Setup (once)
       - Checkout code
-      - Setup Node.js 22 (LTS)
+      - Setup Node.js 24 (LTS)
       - Install dependencies
 
       # 2. Build
@@ -345,7 +345,7 @@ jobs:
 - **Single job design** eliminates redundant setups
 - **Conditional deployment** (main branch only)
 - **Artifact upload** only on failure or PRs (for debugging)
-- **Node.js 22 LTS** for stability and performance
+- **Node.js 24 LTS** for stability and performance
 
 ## Troubleshooting
 

--- a/GITHUB_ACTIONS.md
+++ b/GITHUB_ACTIONS.md
@@ -56,7 +56,7 @@ docker-compose-tests (parallel: CouchDB + MongoDB)
 
 **Execution Flow**:
 ```
-Setup (checkout, Node.js 22, npm install)
+Setup (checkout, Node.js 24, npm install)
    ↓
 Generate (JSDoc documentation build)
    ↓
@@ -341,7 +341,7 @@ export COUCHDB_DATABASE="your_database"
 **Local development:**
 ```bash
 # Node.js LTS version (required)
-node --version    # Should be 22.x
+node --version    # Should be 24.x
 
 # Documentation generation
 npm run docs                           # Generate docs
@@ -357,11 +357,15 @@ node scripts/check-docs-coverage.js    # Quality check
 
 **Node.js Requirements:**
 ```json
-"engines": {
-  "node": ">=22.0.0 <23.0.0",  // LTS 22.x only
-  "npm": ">=10.0.0"
+{
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  }
 }
 ```
+
+Support is maintained for Node.js 20, 22, and 24, with 24 being the primary version used for coverage and documentation.
 
 ## 🎯 Best Practices
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,15 @@ The application follows a layered architecture with a clear separation of concer
 
 This design allows for easy switching between database vendors by implementing a new repository that adheres to the repository interface.
 
-## Prerequisites
+### Node.js Requirements:
 
-These are the versions this sample app is coming with:
-
-- Node.js (v22 or higher)
+- Node.js (v20, v22, or v24 LTS)
 - npm or pnpm
 - One of the following databases:
   - CouchDB (v3.5.1 or higher)
   - MongoDB (v7.0.28 or higher)
 
-Stable work on lower versions is not guaranteed.
+Stable work on other versions is not guaranteed. Node.js v24 is the primary development and CI version.
 
 ## Installation
 

--- a/notes.Dockerfile
+++ b/notes.Dockerfile
@@ -1,14 +1,14 @@
 # syntax=docker/dockerfile:1
 
 # Build stage: install only production dependencies
-FROM node:22.21.1-alpine3.22 AS builder
+FROM node:24.12.0-alpine3.23 AS builder
 WORKDIR /app
 COPY package*.json ./
 # Install reproducible, production-only deps and clean cache
 RUN npm ci --only=production && npm cache clean --force
 
 # Runtime stage: minimal image, non-root user
-FROM node:22.21.1-alpine3.22 AS runner
+FROM node:24.12.0-alpine3.23 AS runner
 # Install wget for health checks
 RUN apk add --no-cache wget
 ENV NODE_ENV=production

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "testcontainers": "^11.7.1"
       },
       "engines": {
-        "node": ">=22.0.0 <23.0.0",
+        "node": ">=20.0.0",
         "npm": ">=10.0.0"
       }
     },
@@ -60,6 +60,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1464,6 +1465,7 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -2379,6 +2381,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "src/notes-api-server.js",
   "type": "module",
   "engines": {
-    "node": ">=22.0.0 <=24.0.0",
+    "node": ">=20.0.0",
     "npm": ">=10.0.0"
   },
   "scripts": {


### PR DESCRIPTION
- Update workflows, Dockerfiles, and documentation to prioritize Node.js 24 LTS.
- Adjust CI matrix and Codecov to use Node.js 24 for coverage.
- Update `engines` field in `package.json` and align dependencies for broader compatibility.